### PR TITLE
Rewrite zig implementation to be more idiomatic

### DIFF
--- a/src/zig/build.zig
+++ b/src/zig/build.zig
@@ -15,11 +15,17 @@ pub fn build(b: *std.Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable(.{
-        .name = "brainfetch",
+    const exe_mod = b.addModule("brainfetch", .{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+    });
+    exe_mod.strip = b.option(bool, "strip", "remove debug info");
+
+    // An executable has a root module and name
+    const exe = b.addExecutable(.{
+        .name = "brainfetch",
+        .root_module = exe_mod,
     });
 
     // This declares intent for the executable to be installed into the

--- a/src/zig/build.zig.zon
+++ b/src/zig/build.zig.zon
@@ -1,10 +1,7 @@
 .{
     .name = .brainfetch,
-
     .version = "0.0.0",
-
     .fingerprint = 0x9c97040fbdfb6163,
-
     .dependencies = .{},
 
     // Specifies the set of files and directories that are included in this package.


### PR DESCRIPTION
This PR rewrites the Zig interpreter implementation to be more idiomatic - This allows for easier optimizations in the future, and generally better understanding of the code.

As a positive side effect, the interpreter now recognizes malformed BF code (mismatched loops) that may have been overseen earlier, and now correctly handles memory in all scenarios.

As a negative side effect, there is an unknown ~4.5% regression in speed on running the mandelbrot program.

Additionally, the build script has been modified to support the `-Dstrip` command, producing binaries that are stripped of debug info. This is *not* the same as running `strip` on the resulting program; this option also disables debug-specific code in the binary that would not otherwise be removed, such as the error trace code.

PS: should I submit a PR for a BF-to-Zig transpiler for BF? The compiled result would 100% be faster than an interpreter, and it would be nice to have more variety in that domain.